### PR TITLE
[SD-3642] Added fck to the list of profane words

### DIFF
--- a/profanities.go
+++ b/profanities.go
@@ -103,6 +103,7 @@ var profanities = []string{
 	"fannyflaps",
 	"fannyfucker",
 	"fatass",
+	"fck",
 	"fcuk",
 	"fcuker",
 	"fcuking",


### PR DESCRIPTION
Added fck to the profane list. The reason we needed to do this was because `*` characters are removed, and thus f*ck is slipping by!